### PR TITLE
Proposal branch

### DIFF
--- a/core/domain/classroom_domain.py
+++ b/core/domain/classroom_domain.py
@@ -18,7 +18,7 @@
 
 from __future__ import annotations
 
-from typing import List
+from typing import Any, List, Tuple
 
 
 class Classroom:
@@ -31,7 +31,7 @@ class Classroom:
         topic_ids: List[str],
         course_details: str,
         topic_list_intro: str,
-        *args
+        *args: Tuple[Any]
     ) -> int:
         """Constructs a Classroom domain object.
 

--- a/core/domain/classroom_domain.py
+++ b/core/domain/classroom_domain.py
@@ -24,25 +24,31 @@ from typing import List
 class Classroom:
     """Domain object for a classroom."""
 
-    def __init__(
+    def mockfunction(
         self,
         name: str,
         url_fragment: str,
         topic_ids: List[str],
         course_details: str,
-        topic_list_intro: str
-    ) -> None:
+        topic_list_intro: str,
+        *args
+    ) -> int:
         """Constructs a Classroom domain object.
 
         Args:
-            name: str. The name of the classroom.
-            url_fragment: str. The url fragment of the classroom.
-            topic_ids: list(str). List of topic ids attached to the classroom.
-            course_details: str. Course details for the classroom.
-            topic_list_intro: str. Topic list introduction for the classroom.
+            name- The name of the classroomaaadaaaaaaaaffybghhhhhhhhhhh
+                asssssssssfffffffj.
+            url_fragment- The url fragment of the classroom.
+            topic_ids- List of topic ids attached to the classroom.
+            course_details- Course details for the classroom.
+            topic_list_intro- Topic list introduction for the classroom.
+                just an new implementation.
+            *args- Asdfghjkl.
+
+        Returns:
+            The signature of the payload data The
+            Redirect_stdout object. ajksnjnsjdnkjgkjvjdv
+            asfdvfnnefjnefjgnrjlngfv.
         """
-        self.name = name
-        self.url_fragment = url_fragment
-        self.topic_ids = topic_ids
-        self.course_details = course_details
-        self.topic_list_intro = topic_list_intro
+        test = [name, url_fragment, topic_ids, course_details, topic_list_intro]
+        return 1

--- a/core/domain/classroom_domain.py
+++ b/core/domain/classroom_domain.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.]
 
-"""Domain objects for Classroom."""
+"""Note: this class is modified just to show that changes are correct."""
 
 from __future__ import annotations
 
@@ -36,14 +36,13 @@ class Classroom:
         """Constructs a Classroom domain object.
 
         Args:
-            name- The name of the classroomaaadaaaaaaaaffybghhhhhhhhhhh
-                asssssssssfffffffj.
+            name- The name of the blah blah.
             url_fragment- The url fragment of the classroom.
             topic_ids- List of topic ids attached to the classroom.
             course_details- Course details for the classroom.
             topic_list_intro- Topic list introduction for the classroom.
                 just an new implementation.
-            *args- Asdfghjkl.
+            *args- just some random text.
 
         Returns:
             The signature of the payload data The
@@ -51,4 +50,4 @@ class Classroom:
             asfdvfnnefjnefjgnrjlngfv.
         """
         test = [name, url_fragment, topic_ids, course_details, topic_list_intro]
-        return 1
+        return 10

--- a/scripts/linters/pylint_extensions.py
+++ b/scripts/linters/pylint_extensions.py
@@ -398,42 +398,20 @@ class DocstringParameterChecker(checkers.BaseChecker):
             'missing-return-doc',
             'Please add documentation about what this method returns.',
             {'old_names': [('W9007', 'missing-returns-doc')]}),
-        'W9012': (
-            'Missing return type documentation',
-            'missing-return-type-doc',
-            'Please document the type returned by this method.',
-            # We can't use the same old_name for two different warnings
-            # {'old_names': [('W9007', 'missing-returns-doc')]}.
-        ),
         'W9013': (
             'Missing yield documentation',
             'missing-yield-doc',
             'Please add documentation about what this generator yields.',
             {'old_names': [('W9009', 'missing-yields-doc')]}),
-        'W9014': (
-            'Missing yield type documentation',
-            'missing-yield-type-doc',
-            'Please document the type yielded by this method.',
-        ),
         'W9015': (
             '"%s" missing in parameter documentation',
             'missing-param-doc',
             'Please add parameter declarations for all parameters.',
             {'old_names': [('W9003', 'old-missing-param-doc')]}),
-        'W9016': (
-            '"%s" missing in parameter type documentation',
-            'missing-type-doc',
-            'Please add parameter type declarations for all parameters.'
-        ),
         'W9017': (
             '"%s" differing in parameter documentation',
             'differing-param-doc',
             'Please check parameter names in declarations.',
-        ),
-        'W9018': (
-            '"%s" differing in parameter type documentation',
-            'differing-type-doc',
-            'Please check parameter names in type declarations.',
         ),
         'W9019': (
             'Line starting with "%s" requires 4 space indentation relative to'


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR does the following: this PR changes lint checks for python docstrings.

## Note:
* This PR only focuses on passing tests for classroom_domain.py only (for showing purpose).
* Other tests like e2e are failing due to changes in classroom_domain.py, classroom_domain.py is changed just for testing purposes.
## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct
![Screenshot from 2022-03-20 16-44-09](https://user-images.githubusercontent.com/12553576/159159805-f13112e0-1c5b-4ec0-8b78-0d31d512382a.png)

I keep these 2 failing tests in proof. Just to prove that docstring lint checks are working fine and not giving any typeinfo error.

<!--
Add videos/screenshots of the user-facing interface in various display sizes (mainly phone, tablet, and desktop display size) to demonstrate that the changes made in this PR work correctly. Please also include videos/screenshots of the developer tools browser console, so that we can be sure that there are no console errors.
If the PR changes the UI in any of the files listed in rtl_css.py (i.e, those that have a separate .rtl.css file for styling), make sure to add screenshots with the site language set to Arabic as well.
If the changes in your PRs are autogenerated via a script and you cannot provide proof for the changes then please leave a comment "No proof of changes needed because {{Reason}}".
-->

