### PR TITLE
Refactoring `registry_test` to remove `# type: ignore` pragmas.

### DIFF
--- a/core/jobs/registry_test.py
+++ b/core/jobs/registry_test.py
@@ -22,46 +22,47 @@ from core.jobs import base_jobs
 from core.jobs import registry
 from core.tests import test_utils
 
-from typing import Type
+from typing_extensions import Final
 
 
 class RegistryTests(test_utils.TestBase):
 
-    def test_get_all_jobs_returns_value_from_job_metaclass(self) -> None:
-        unique_obj = object()
+    UNIQUE_OBJ: Final = object()
 
-        @classmethod # type: ignore[misc]
-        def get_all_jobs_mock(
-            unused_cls: Type[base_jobs.JobMetaclass]
-        ) -> object:
-            """Returns the unique_obj."""
-            return unique_obj
+    @classmethod
+    def get_all_jobs_mock(cls) -> object:
+        """Returns the UNIQUE_OBJ."""
+        return cls.UNIQUE_OBJ
+
+    @classmethod
+    def get_all_job_names_mock(cls) -> object:
+        """Returns the UNIQUE_OBJ."""
+        return cls.UNIQUE_OBJ
+
+    @classmethod
+    def get_job_class_by_name_mock(cls, unused_name: str) -> object:
+        """Returns the UNIQUE_OBJ."""
+        return cls.UNIQUE_OBJ
+
+    def test_get_all_jobs_returns_value_from_job_metaclass(self) -> None:
 
         get_all_jobs_swap = self.swap(
-            base_jobs.JobMetaclass, 'get_all_jobs', get_all_jobs_mock)
+            base_jobs.JobMetaclass, 'get_all_jobs', self.get_all_jobs_mock)
 
         with get_all_jobs_swap:
-            self.assertIs(registry.get_all_jobs(), unique_obj)
+            self.assertIs(registry.get_all_jobs(), self.UNIQUE_OBJ)
 
     def test_get_all_jobs_never_returns_an_empty_list(self) -> None:
         self.assertNotEqual(registry.get_all_jobs(), [])
 
     def test_get_all_job_names_returns_value_from_job_metaclass(self) -> None:
-        unique_obj = object()
-
-        @classmethod # type: ignore[misc]
-        def get_all_job_names_mock(
-            unused_cls: Type[base_jobs.JobMetaclass]
-        ) -> object:
-            """Returns the unique_obj."""
-            return unique_obj
 
         get_all_job_names_swap = self.swap(
             base_jobs.JobMetaclass,
-            'get_all_job_names', get_all_job_names_mock)
+            'get_all_job_names', self.get_all_job_names_mock)
 
         with get_all_job_names_swap:
-            self.assertIs(registry.get_all_job_names(), unique_obj)
+            self.assertIs(registry.get_all_job_names(), self.UNIQUE_OBJ)
 
     def test_get_all_job_names_never_returns_an_empty_list(self) -> None:
         self.assertNotEqual(registry.get_all_job_names(), [])
@@ -69,20 +70,11 @@ class RegistryTests(test_utils.TestBase):
     def test_get_job_class_by_name_returns_value_from_job_metaclass(
         self
     ) -> None:
-        unique_obj = object()
-
-        @classmethod # type: ignore[misc]
-        def get_job_class_by_name_mock(
-            unused_cls: Type[base_jobs.JobMetaclass],
-            unused_name: str
-        ) -> object:
-            """Returns the unique_obj."""
-            return unique_obj
 
         get_job_class_by_name_swap = self.swap(
             base_jobs.JobMetaclass,
-            'get_job_class_by_name', get_job_class_by_name_mock)
+            'get_job_class_by_name', self.get_job_class_by_name_mock)
 
         with get_job_class_by_name_swap:
             self.assertIs(
-                registry.get_job_class_by_name('arbitrary'), unique_obj)
+                registry.get_job_class_by_name('arbitrary'), self.UNIQUE_OBJ)


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of N/A.
2. This PR does the following: Refactors the register_test.py so that classmethod does not have to be defined with pragmas. 

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface.

Please also include videos/screenshots of the developer tools
browser console, so that we can be sure that there are no console errors.

If the changes in your PRs are autogenerated via a script and you cannot provide proof
for the changes then please leave a comment "No proof of changes needed because {{Reason}}"
and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI in any of the files listed in rtl_css.py (i.e, those that have
a separate .rtl.css file for styling), make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
